### PR TITLE
Use dbus-glib 0.110 from shared-modules

### DIFF
--- a/Avoid-depending-on-static-libraries.patch
+++ b/Avoid-depending-on-static-libraries.patch
@@ -167,7 +167,7 @@ index 0b783ec21..c438f1074 100644
                  'qt_version%': '5.3.2',
                }, {
 -                'qt_version%': '5.6.2',
-+                'qt_version%': '5.9.6',
++                'qt_version%': '5.9.7',
                }]
              ],
            },

--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -37,17 +37,7 @@
         }
     },
     "modules": [
-        {
-            "name": "dbus-glib",
-            "config-opts": [ "--disable-static" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
-                    "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
-                }
-            ]
-        },
+        "shared-modules/dbus-glib/dbus-glib-0.110.json",
         "shared-modules/libappindicator/libappindicator-gtk3-12.10.json",
         {
             "name": "dee",


### PR DESCRIPTION
And an update for the Qt version currently in the SDK.

https://github.com/flathub/shared-modules/pull/37