### PR TITLE
Remove obsolete build flags

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -20,14 +20,6 @@
                  "/share/man",
                  "/lib/systemd",
                  "*.la", "*.a"],
-    "build-options" : {
-        "cflags": "-O2 -g -Wno-deprecated-declarations -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIC",
-        "cxxflags": "-O2 -g -Wno-deprecated-declarations -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIC",
-        "ldflags": "-fstack-protector-strong -Wl,-z,relro,-z,now",
-        "env": {
-            "V": "1"
-        }
-    },
     "modules": [
         {
             "name": "dee",


### PR DESCRIPTION
Telegram is now based on the KDE 5.12/fd.o 18.08 runtime, which already implicitly sets these flags.