### PR TITLE
Add xdg-download permission

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -14,6 +14,7 @@
                      "--socket=pulseaudio",
                      "--talk-name=org.kde.StatusNotifierWatcher",
                      "--talk-name=org.freedesktop.Notifications",
+                     "--filesystem=xdg-download",
                      "--device=dri" ],
     "cleanup": [ "/cache",
                  "/man",


### PR DESCRIPTION
Telegram downloads media to `$XDG_DOWNLOAD_DIR/Telegram Desktop` by default, when viewed in the client. File dialog (and thus portal) isn't involved in it, so, without this permission, downloaded files are stored inside sandbox.