### PR TITLE
Allow access to com.canonical.Unity

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -15,6 +15,7 @@
                      "--socket=pulseaudio",
                      "--talk-name=org.kde.StatusNotifierWatcher",
                      "--talk-name=org.freedesktop.Notifications",
+                     "--talk-name=com.canonical.Unity",
                      "--talk-name=org.freedesktop.portal.Fcitx",
                      "--filesystem=xdg-download",
                      "--device=dri" ],


### PR DESCRIPTION
This is needed for unread messages counter on the dock icon.