### PR TITLE
Don't bundle opus

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -40,16 +40,6 @@
             ]
         },
         {
-            "name": "opus",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://archive.mozilla.org/pub/opus/opus-1.3.tar.gz",
-                    "sha256": "4f3d69aefdf2dbaf9825408e452a8a414ffc60494c70633560700398820dc550"
-                }
-            ]
-        },
-        {
             "name": "ffmpeg",
             "config-opts": [
                 "--disable-programs",


### PR DESCRIPTION
It's provided in runtime. It should also fix issues after recent qt update in runtime.