### PR TITLE
fc-custom.conf: add /run/host/fonts to fontconfig search path

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -235,6 +235,10 @@
                     "path": "patch/telegram-appdata.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "patch/telegram-fontconfig-use-host-fonts.patch"
+                },
+                {
                     "type": "file",
                     "path": "patch/CMakeLists.inj"
                 },

--- a/patch/telegram-fontconfig-use-host-fonts.patch
+++ b/patch/telegram-fontconfig-use-host-fonts.patch
@@ -1,0 +1,26 @@
+From cc080dfaddcbf0d6807128839d4f99bcbb9b3038 Mon Sep 17 00:00:00 2001
+From: Andrew Hayzen <ahayzen@gmail.com>
+Date: Sun, 8 Dec 2019 00:43:46 +0000
+Subject: [PATCH] fc-custom.conf: add /run/host/fonts to fontconfig search path
+
+This resolves issues with flatpak where CJK cannot be found
+on the host.
+---
+ Telegram/Resources/fc-custom.conf | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Telegram/Resources/fc-custom.conf b/Telegram/Resources/fc-custom.conf
+index ab5c18306..5c97a73bf 100644
+--- a/Telegram/Resources/fc-custom.conf
++++ b/Telegram/Resources/fc-custom.conf
+@@ -6,6 +6,7 @@
+ 	<dir>~/.fonts</dir>
+ 	<dir>~/.local/share/fonts</dir>
+ 	<dir>/usr/X11R6/lib/X11/fonts</dir>
++	<dir>/run/host/fonts</dir>
+ 	<dir prefix="xdg">fonts</dir>
+ 	<match target="pattern">
+ 		<test qual="any" name="family">
+-- 
+2.20.1
+


### PR DESCRIPTION
This resolves issues with flatpak where CJK cannot be found on the host.

Note that users that have already executed telegram will need to run `sudo rm ~/.var/app/org.telegram.desktop/data/TelegramDesktop/tdata/fc-custom-1.conf` to clear the existing "wrong" font config file. Then when Telegram is started with this patch it will install the correct fc-custom file.

Also note that the Resources folder in telegram appears to be split into a submodule in future releases, so this patch will need to be instead run against the submodule for the future 1.9.X series ( eg fc-custom.conf has moved from here https://github.com/telegramdesktop/tdesktop/blob/v1.8.15/Telegram/Resources/fc-custom.conf to here https://github.com/desktop-app/lib_ui/blob/master/qt_conf/fc-custom.conf )

I also wonder if we should contribute this change upstream ? Or would they not accept such a directory (`/run/host/fonts`) in the upstream fontconfig file ?

Closes #63