### PR TITLE
Drop shared-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -39,8 +39,6 @@
                  "/lib/cmake",
                  "*.la", "*.a"],
     "modules": [
-        "shared-modules/dbus-glib/dbus-glib-0.110.json",
-        "shared-modules/libappindicator/libappindicator-gtk3-12.10.json",
         {
             "name": "cmake",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
AppIndicator was replaced with dbusmenu-qt (present in the runtime), so we don't need libappindicator and dbus-glib anymore.