### PR TITLE
Force xcb platform only on Gnome

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -4,7 +4,7 @@
     "runtime-version": "5.14",
     "sdk": "org.kde.Sdk",
     "default-branch": "stable",
-    "command": "telegram-wrapper",
+    "command": "telegram-desktop",
     "rename-icon": "telegram",
     "finish-args": [ "--share=ipc",
                      "--share=network",
@@ -180,8 +180,8 @@
                 "-DTDESKTOP_API_HASH=d524b414d21f4d37f08684c1df41ac9c"
             ],
             "post-install": [
-                "install -Dm755 ../telegram-wrapper.sh /app/bin/telegram-wrapper",
-                "desktop-file-edit --set-key=Exec --set-value=telegram-wrapper /app/share/applications/${FLATPAK_ID}.desktop",
+                "mv /app/bin/telegram-desktop{,.bin}",
+                "install -Dm755 ../telegram-wrapper.sh /app/bin/telegram-desktop",
                 "../changelog2appdata.py -c ../changelog.txt -a /app/share/metainfo/${FLATPAK_ID}.appdata.xml -n 10"
             ],
             "sources": [

--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -4,12 +4,13 @@
     "runtime-version": "5.14",
     "sdk": "org.kde.Sdk",
     "default-branch": "stable",
-    "command": "telegram-desktop",
+    "command": "telegram-wrapper",
     "rename-icon": "telegram",
     "finish-args": [ "--share=ipc",
                      "--share=network",
                      "--socket=x11",
                      "--socket=wayland",
+                     "--device=dri",
                      "--socket=pulseaudio",
                      "--talk-name=org.kde.StatusNotifierWatcher",
                      "--talk-name=org.freedesktop.Notifications",
@@ -18,9 +19,7 @@
                      "--talk-name=org.ayatana.indicator.application",
                      "--talk-name=org.freedesktop.portal.Fcitx",
                      "--talk-name=org.freedesktop.ScreenSaver",
-                     "--filesystem=xdg-download",
-                     "--device=dri",
-                     "--env=QT_QPA_PLATFORM=xcb"],
+                     "--filesystem=xdg-download"],
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
@@ -181,6 +180,8 @@
                 "-DTDESKTOP_API_HASH=d524b414d21f4d37f08684c1df41ac9c"
             ],
             "post-install": [
+                "install -Dm755 ../telegram-wrapper.sh /app/bin/telegram-wrapper",
+                "desktop-file-edit --set-key=Exec --set-value=telegram-wrapper /app/share/applications/${FLATPAK_ID}.desktop",
                 "../changelog2appdata.py -c ../changelog.txt -a /app/share/metainfo/${FLATPAK_ID}.appdata.xml -n 10"
             ],
             "sources": [
@@ -193,6 +194,10 @@
                 {
                     "type": "patch",
                     "path": "patches/Fix-decoration-applying.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "telegram-wrapper.sh"
                 },
                 {
                     "type": "file",

--- a/telegram-wrapper.sh
+++ b/telegram-wrapper.sh
@@ -6,4 +6,4 @@ if [ "${XDG_CURRENT_DESKTOP,,}" == "gnome" ] | [ "${XDG_SESSION_DESKTOP,,}" == "
     fi
 fi
 
-exec telegram-desktop "$@"
+exec telegram-desktop.bin "$@"

--- a/telegram-wrapper.sh
+++ b/telegram-wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${XDG_CURRENT_DESKTOP,,}" == "gnome" ] | [ "${XDG_SESSION_DESKTOP,,}" == "gnome" ]; then
+if [ "${XDG_CURRENT_DESKTOP,,}" == "gnome" ] || [ "${XDG_SESSION_DESKTOP,,}" == "gnome" ]; then
     if [ -z "$QT_QPA_PLATFORM" ]; then
         export QT_QPA_PLATFORM=xcb
     fi

--- a/telegram-wrapper.sh
+++ b/telegram-wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${XDG_CURRENT_DESKTOP,,}" == "gnome" ] || [ "${XDG_SESSION_DESKTOP,,}" == "gnome" ]; then
+if [[ "${XDG_CURRENT_DESKTOP,,}" =~ "gnome" ]] || [[ "${XDG_SESSION_DESKTOP,,}" =~ "gnome" ]]; then
     if [ -z "$QT_QPA_PLATFORM" ]; then
         export QT_QPA_PLATFORM=xcb
     fi

--- a/telegram-wrapper.sh
+++ b/telegram-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "${XDG_CURRENT_DESKTOP,,}" == "gnome" ] | [ "${XDG_SESSION_DESKTOP,,}" == "gnome" ]; then
+    if [ -z "$QT_QPA_PLATFORM" ]; then
+        export QT_QPA_PLATFORM=xcb
+    fi
+fi
+
+exec telegram-desktop "$@"


### PR DESCRIPTION
Telegram should work fine now on other wayland DEs. Testing wanted.
Partially fixes #170.