### PR TITLE
Don't force XWayland

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -95,8 +95,6 @@
                 "-DTDESKTOP_API_HASH=d524b414d21f4d37f08684c1df41ac9c"
             ],
             "post-install": [
-                "mv /app/bin/telegram-desktop{,.bin}",
-                "install -Dm755 ../../telegram-wrapper.sh /app/bin/telegram-desktop",
                 "../../changelog2appdata.py -c ../changelog.txt -a /app/share/metainfo/${FLATPAK_ID}.appdata.xml -n 10"
             ],
             "subdir": "tdesktop",
@@ -107,10 +105,6 @@
                     "tag": "v2.4.0",
                     "commit": "11e03a181d267447694c39e39df9c30ec5f9b52e",
                     "dest": "tdesktop"
-                },
-                {
-                    "type": "file",
-                    "path": "telegram-wrapper.sh"
                 },
                 {
                     "type": "file",

--- a/telegram-wrapper.sh
+++ b/telegram-wrapper.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ "${XDG_CURRENT_DESKTOP,,}" =~ "gnome" ]] || [[ "${XDG_SESSION_DESKTOP,,}" =~ "gnome" ]]; then
-    if [ -z "$QT_QPA_PLATFORM" ]; then
-        export QT_QPA_PLATFORM=xcb
-    fi
-fi
-
-exec telegram-desktop.bin "$@"


### PR DESCRIPTION
This effectively reverts #163
It seems like running Telegram with XWayland on Gnome started to cause more problems than it used to solve, as reported in #194 #193 #191.
Also it appears that autostarted Telegram didn't use the wrapper at all.