### PR TITLE
Allow access to common xdg directories

### DIFF
--- a/org.telegram.desktop.json
+++ b/org.telegram.desktop.json
@@ -22,7 +22,11 @@
                      "--talk-name=org.gnome.Mutter.IdleMonitor",
                      "--talk-name=org.freedesktop.FileManager1",
                      "--system-talk-name=org.freedesktop.NetworkManager",
-                     "--filesystem=xdg-download"],
+                     "--filesystem=xdg-documents",
+                     "--filesystem=xdg-download",
+                     "--filesystem=xdg-music",
+                     "--filesystem=xdg-pictures",
+                     "--filesystem=xdg-videos"],
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",


### PR DESCRIPTION
It's unknown how long we will need to wait for FileTransfer portal in qt, so for now set `--filesystem=home` as workaround for users.