### PR TITLE
Give access to PipeWire to be able to share screen

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -22,6 +22,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-download
+  - --filesystem=xdg-run/pipewire-0
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg


### PR DESCRIPTION
Latest Telegram update now has support for sharing screen (https://telegram.org/blog/group-video-calls) for it to work on the flatpak it would require to have access to PipeWire. 

