### PR TITLE
Remove unnecessary filesystem permission

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -22,7 +22,6 @@ finish-args:
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-download
   - --filesystem=xdg-run/pipewire-0
-  - --filesystem=host:ro
   - --nofilesystem=~/.TelegramDesktop
   - --env=QT_PLUGIN_PATH=/app/lib64/plugins:/app/lib/plugins
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin


### PR DESCRIPTION
This permission grants grants the sandbox read access to the entire
local filesystem (including any sensitive keys or data).

However, Telegram uses the File Chooser portal to pick files (e.g.: when
sending a file to a contact), which allows Flatpak applications to pick
any file through it (that is, even files outside the sandbox).

Effectively, even without the `filesystem=host:ro` permission it is
possible to select and send files from any location.