### PR TITLE
Revert "Remove no longer needed xdg-download permission"

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -20,6 +20,7 @@ finish-args:
   - --talk-name=com.canonical.Unity
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
+  - --filesystem=xdg-download
   - --filesystem=xdg-run/pipewire-0
   - --env=QT_PLUGIN_PATH=/app/lib/plugins
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin


### PR DESCRIPTION
This reverts commit e1a0bb0f2ac3937245bf055b2eeb38725c619fd6.

The commit introduced a regression where Telegram would now open multiple file portals when opening chats containing not yet downloaded file.

I also refer to my comment on the corresponding PR: https://github.com/flathub/org.telegram.desktop/pull/456#issuecomment-1304887064