### PR TITLE
Specify minimum flatpak version

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -5,6 +5,7 @@ sdk: org.freedesktop.Sdk
 command: telegram-desktop
 rename-icon: telegram
 finish-args:
+  - --require-version=1.11.1
   - --share=ipc
   - --share=network
   - --socket=wayland


### PR DESCRIPTION
Since migration to Qt 6, people periodically creating issues about incorrect single instance check in flatpak. This goes from the fact Qt 6 does permission checks on the XDG_RUNTIME_DIR and there's no easy way to work around that, so declare we don't support those flatpak versions. Specifying the version that added shared /tmp support.