### PR TITLE
Grant `xdg-download` permission for ability to choose a custom download path

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -17,6 +17,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=xdg-download
   - --env=QT_PLUGIN_PATH=/app/lib/plugins
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin
 sdk-extensions:


### PR DESCRIPTION
Fixes an issue that prevents users from setting a custom download directory. 
The issue is caused by a missing permission for `xdg-download`, which is needed for the `Custom folder` option to work (that is under `settings -> advanced -> download path`.

With this fix, users can now choose a custom download directory.