### PR TITLE
Switch QT_PLUGIN_PATH to unset-env

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -17,7 +17,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-run/pipewire-0
-  - --env=QT_PLUGIN_PATH=/app/lib/plugins
+  - --unset-env=QT_PLUGIN_PATH
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm15


### PR DESCRIPTION
Qt's default path is good, we just need to ensure it's not overridable