### PR TITLE
add home filesystem access

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -16,6 +16,7 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
+  - --filesystem=home
   - --filesystem=xdg-run/pipewire-0
   - --unset-env=QT_PLUGIN_PATH
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin


### PR DESCRIPTION
Sending files and media is a wide usecase in messengers, such as Telegram. In case of this Flatpack version, picking a file is either impossible due to a seemingly empty file system, or, when dropped via Drag&Drop, the transmission fails with an error about the file being empty.

To a user oblivious to the Flatpack rights management, the app appears to be simply broken. Trouble shooting search on the internet showed that many other users suggest to simply install Telegram from a source other than Flatpack. 

Since users would typically send files from within their home directory, file system access restricted to their home dir should suffice.