### PR TITLE
Revert "Avoid qtsvg 6.6.0"

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -496,8 +496,6 @@ modules:
           type: anitya
           project-id: 7927
           url-template: https://download.qt.io/archive/qt/$major.$minor/$version/submodules/qtsvg-everywhere-src-$version.tar.xz
-          versions:
-            <: 6.6.0
 
   - name: tg_owt
     buildsystem: cmake-ninja


### PR DESCRIPTION
This reverts commit ba1830c50c07fe0b38055f6c8eb2e6461f145f96.