### PR TITLE
Use freedesktop 24.08 SDK & runtime

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -1,6 +1,6 @@
 id: org.telegram.desktop
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: telegram-desktop
 rename-icon: telegram
@@ -25,7 +25,7 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
     add-ld-path: .
-    version: '23.08'
+    version: '24.08'
     autodownload: true
     autodelete: false
   org.telegram.desktop.webview:


### PR DESCRIPTION
As the new stable version of Freedesktop SDK is released. This PR updates the SDK and runtime to freedesktop 24.08.