### PR TITLE
Revert "Have less debug info on aarch64 to avoid OOM build failures"

### DIFF
--- a/org.telegram.desktop.yml
+++ b/org.telegram.desktop.yml
@@ -395,11 +395,6 @@ modules:
   - name: tdesktop
     buildsystem: cmake-ninja
     builddir: true
-    build-options:
-      arch:
-        aarch64:
-          cflags: -g1
-          cxxflags: -g1
     config-opts:
       - -DTDESKTOP_API_ID=611335
       - -DTDESKTOP_API_HASH=d524b414d21f4d37f08684c1df41ac9c


### PR DESCRIPTION
This reverts commit 5cc96301888e190b2e41d9fb93a4f84aea1e4dce.